### PR TITLE
Remove linting error in newly generated projects

### DIFF
--- a/_app/pages/home.js
+++ b/_app/pages/home.js
@@ -11,7 +11,7 @@ module.exports = function (state, prev, send) {
     </main>
   `
 
-  function update(e) {
+  function update (e) {
     send('update', e.target.value)
   }
 }


### PR DESCRIPTION
There was a `Missing space before function parentheses` error when running `npm run lint` before.